### PR TITLE
Fix construction without `new`

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -16,7 +16,7 @@ function backoff (current, max, step, _value) {
 
 var Twitter = function (oauth) {
   if(!(this instanceof Twitter)) {
-    return new Tweets(arguments)
+    return new Twitter(arguments)
   }
 
   if (!oauth || !(oauth.consumer_secret || oauth.consumer_key || oauth.token || oauth.token_secret)) {


### PR DESCRIPTION
Shorthand construction `require('node-twitter-stream')({})` now works.
