### PR TITLE
Added ability to filter locations

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -27,7 +27,6 @@ var Twitter = function (oauth) {
   }
   this.oauth = oauth
 
-  this._tracking = {}
   this._filters = {
     tracking: {},
     location: {}


### PR DESCRIPTION
Spruced it up a little bit with some location tracking. The approach doesn't change from how you held onto `tracking` objects, other than creating a sibling `location` object to track. It's set up like this:

``` javascript
filters = {
  trackings: {}, // same as before, just now part of filters, and sibling of locations
  locations: {}
}
```

`track()` is now abstracted by `addFilter`, which is now used by both `track()` and `location()`

`untrack()` is now abstracted by `removeFilter`, which is now used by both `untrack()` and `unlocate()`

`connect()` checks if there are _either_ `location` or `tracking` filters before connecting.

Also added a couple tests for it.

:)
