### PR TITLE
reconnect on timeout

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -188,7 +188,7 @@ Twitter.prototype.connect = function () {
       // Handle this: https://dev.twitter.com/docs/streaming-apis/connecting#Stalls
       var close = (function () {
           if (this.stream) {
-            this.abort()
+            this.stream.emit('error', new Error('Twitter connection time out'))
           }
         }).bind(this)
         , interval = 1000 * 90 // twitter timeout is 90 seconds


### PR DESCRIPTION
It seems that we have to reconnect when no data for 90 seconds according to the docs.
We also had a similar issue with #11. I think this PR would solve it.

https://dev.twitter.com/streaming/overview/connecting#Stalls

> If 90 seconds pass with no data received, including newlines, disconnect and reconnect immediately according to the backoff strategies in the next section.
