### PR TITLE
no maximum delay for HTTP 420 errors

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -50,7 +50,7 @@ Twitter.prototype.backoffs = function () {
   // Rate limited. Try exponetially starting at 5 seconds
   this.httpBackoff = backoff(5 * 1000, 320 * 1000, function (x) { return x * 2 })
   // Rate limited. Try exponetially starting at a minute
-  this.rateBackoff = backoff(60 * 1000, 320 * 1000, function (x) { return x * 2 })
+  this.rateBackoff = backoff(60 * 1000, Infinity, function (x) { return x * 2 })
 }
 
 Twitter.prototype.addFilter = function (filter, keyword, reconnect) {


### PR DESCRIPTION
There is no max delay time for HTTP 420 errors according to the docs.

> Note that every HTTP 420 received increases the time you must wait until rate limiting will no longer will be in effect for your account.
