### PR TITLE
Added function for tracking multiple words at once.

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -75,6 +75,14 @@ Twitter.prototype.track = function (keyword, reconnect) {
   this.addFilter(FILTER_TYPE_TRACKING, keyword, reconnect)
 }
 
+Twitter.prototype.trackMulitple = function (keywords, reconnect) {
+  reconnect = typeof reconnect === 'undefined' || reconnect
+  for(index in keywords)
+    this.addFilter(FILTER_TYPE_TRACKING, keywords[index], false)
+  if (reconnect)
+      this.reconnect()
+}
+
 Twitter.prototype.location = function (location, reconnect) {
   this.addFilter(FILTER_TYPE_LOCATION, location, reconnect)
 }

--- a/test/twitter.js
+++ b/test/twitter.js
@@ -111,6 +111,14 @@ describe('twitter', function () {
       assert.equal(twitter._filters.tracking.tacos, 2)
       assert.deepEqual(twitter.tracking(), ['tacos', 'tortas'])
     })
+    
+    it('can start tracking multiple words at once', function () {
+      assert(!twitter.stream)
+      twitter.trackMulitple(['tacos', 'tortas'])
+      assert.equal(twitter._filters.tracking.tacos, 1)
+      assert.equal(twitter._filters.tracking.tortas, 1)
+      assert.deepEqual(twitter.tracking(), ['tacos', 'tortas'])
+    })
 
     it('avoids dups in tracking stream', function () {
       var called = 0


### PR DESCRIPTION
I've added a function which takes a list of keywords and adds them all to filters.tracking.

For each of the terms in the keywords array, the addFilter() function is called like:

    this.addFilter(FILTER_TYPE_TRACKING, keywords[index], false)

I am passing false as the value for reconnect so that if a large list of keywords is passed, then we are not reconnecting a bunch of times.

At the end of the function I perform one reconnect if necessary.

Also aded the corresponding test case.

-Tyler
