### PR TITLE
fix: Oauth credentials check

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -24,7 +24,7 @@ var Twitter = function (oauth) {
     return new Twitter(oauth)
   }
 
-  if (!oauth || !(oauth.consumer_secret || oauth.consumer_key || oauth.token || oauth.token_secret)) {
+  if (!oauth || !oauth.consumer_secret || !oauth.consumer_key || !oauth.token || !oauth.token_secret) {
     throw new Error('Oauth credentials required')
   }
   this.oauth = oauth


### PR DESCRIPTION
Currently, if *any* of the 4 oauth params are specified, the test on L27 will pass and will *not* throw the error on L28.

Consider the following examples:
```js
var a = true, b = true, c = true;
!(a || b || c ); // false as expected

var a = true, b = true, c = null;
!(a || b || c ); // still false, but missing required param `c`!

// fixed version:
var a = true, b = true, c = null;
(!a || !b || !c); // true as expected
```

Also consider handling status code 401 errors inside `Twitter.prototype.connect`.