### PR TITLE
Added untrackAll function

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -161,8 +161,25 @@ Twitter.prototype.removeFilter = function (filter, keyword, reconnect) {
   }
 }
 
+Twitter.prototype.removeAllFilters = function (filter, reconnect) {
+  reconnect = typeof reconnect === 'undefined' || reconnect
+
+  if (typeof this._filters[filter] === 'undefined') {
+    return
+  }
+  this._filters[filter] = {};
+  this.stale = true
+  if (reconnect) {
+    this.reconnect()
+  }
+}
+
 Twitter.prototype.untrack = function (keyword, reconnect) {
   this.removeFilter(FILTER_TYPE_TRACKING, keyword, reconnect)
+}
+
+Twitter.prototype.untrackAll = function (reconnect) {
+  this.removeAllFilters(FILTER_TYPE_TRACKING, reconnect)
 }
 
 Twitter.prototype.unlocate = function (location, reconnect) {

--- a/test/twitter.js
+++ b/test/twitter.js
@@ -130,6 +130,17 @@ describe('twitter', function () {
       assert.deepEqual(twitter.tracking(), ['tacos', 'tortas'])
     })
 
+    it('can untrack all words at once', function () {
+      assert(!twitter.stream)
+      twitter.trackMultiple(['tacos', 'tortas'])
+      assert.equal(twitter._filters.tracking.tacos, 1)
+      assert.equal(twitter._filters.tracking.tortas, 1)
+      assert.deepEqual(twitter.tracking(), ['tacos', 'tortas'])
+      twitter.untrackAll()
+      assert.deepEqual(twitter._filters.tracking, {})
+      assert.deepEqual(twitter.tracking(), [])
+    })
+
     it('avoids dups in tracking stream', function () {
       var called = 0
       twitter.reconnect = function () {
@@ -297,6 +308,14 @@ describe('twitter', function () {
                     language: 'en'
                   })
                   .replyWithFile(200, __dirname + '/mocks/tacos.json')
+      nock('https://stream.twitter.com')
+                  .post('/1.1/statuses/filter.json', {
+                    track: '',
+                    locations: '',
+                    follow: '',
+                    language: 'en,es'
+                  })
+                  .replyWithFile(200, __dirname + '/mocks/tacos.json')
     })
 
     it('tracks dups of same language', function () {
@@ -326,7 +345,6 @@ describe('twitter', function () {
       twitter.language('en')
       assert.deepEqual(twitter.languages(), ['en'])
     })
-
   })
 
   describe('other stream messages', function () {


### PR DESCRIPTION
Added untrackAll function which removes all tracking filters at once.
Added test and a small fix on filters language test (HTTP mock was
missing)