### PR TITLE
Allow the addFilter commands to accept arrays as input

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -59,27 +59,24 @@ Twitter.prototype.backoffs = function () {
   this.rateBackoff = backoff(60 * 1000, Infinity, function (x) { return x * 2 })
 }
 
-Twitter.prototype.addFilter = function (filter, keyword, reconnect) {
+Twitter.prototype.addFilter = function (filter, keywords, reconnect) {
   reconnect = typeof reconnect === 'undefined' || reconnect
-
-  if (this._filters[filter][keyword]) {
-    this._filters[filter][keyword]++
-  } else {
-    this._filters[filter][keyword] = 1
-    this.stale = true
-    if (reconnect) {
-      this.reconnect()
+  if (typeof keywords !== 'object'){
+    keywords = [keywords]
+  }
+  var length = keywords.length
+  var addedNewKeyword = false
+  for (var i = 0; i < length; i++) {
+    var keyword = keywords[i]
+    if (this._filters[filter][keyword]) {
+      this._filters[filter][keyword]++
+    } else {
+      this._filters[filter][keyword] = 1
+      this.stale = true
+      addedNewKeyword = true
     }
   }
-}
-
-Twitter.prototype.addMultipleFilters = function (filter, items, reconnect) {
-  reconnect = typeof reconnect === 'undefined' || reconnect
-  for (index in items) {
-    this.addFilter(filter, items[index], false)
-  }
-
-  if (reconnect) {
+  if (reconnect && addedNewKeyword) {
     this.reconnect()
   }
 }
@@ -89,31 +86,19 @@ Twitter.prototype.track = function (keyword, reconnect) {
 }
 
 Twitter.prototype.trackMultiple = function (keywords, reconnect) {
-  this.addMultipleFilters(FILTER_TYPE_TRACKING, keywords, reconnect)
+  this.addFilter(FILTER_TYPE_TRACKING, keywords, reconnect)
 }
 
 Twitter.prototype.location = function (location, reconnect) {
   this.addFilter(FILTER_TYPE_LOCATION, location, reconnect)
 }
 
-Twitter.prototype.locationMultiple = function (locations, reconnect) {
-  this.addMultipleFilters(FILTER_TYPE_LOCATION, locations, reconnect)
-}
-
 Twitter.prototype.follow = function (follow, reconnect) {
   this.addFilter(FILTER_TYPE_FOLLOW, follow, reconnect)
 }
 
-Twitter.prototype.followMultiple = function (follows, reconnect) {
-  this.addMultipleFilters(FILTER_TYPE_FOLLOW, follows, reconnect)
-}
-
 Twitter.prototype.language = function (lang, reconnect) {
   this.addFilter(FILTER_TYPE_LANGUAGE, lang, reconnect)
-}
-
-Twitter.prototype.languageMultiple = function (langs, reconnect) {
-  this.addMultipleFilters(FILTER_TYPE_LANGUAGE, langs, reconnect)
 }
 
 Twitter.prototype.tracking = function () {

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -73,14 +73,10 @@ Twitter.prototype.addFilter = function (filter, keyword, reconnect) {
   }
 }
 
-Twitter.prototype.track = function (keyword, reconnect) {
-  this.addFilter(FILTER_TYPE_TRACKING, keyword, reconnect)
-}
-
-Twitter.prototype.trackMultiple = function (keywords, reconnect) {
+Twitter.prototype.addMultipleFilters = function (filter, items, reconnect) {
   reconnect = typeof reconnect === 'undefined' || reconnect
-  for (index in keywords) {
-    this.addFilter(FILTER_TYPE_TRACKING, keywords[index], false)
+  for (index in items) {
+    this.addFilter(filter, items[index], false)
   }
 
   if (reconnect) {
@@ -88,16 +84,36 @@ Twitter.prototype.trackMultiple = function (keywords, reconnect) {
   }
 }
 
+Twitter.prototype.track = function (keyword, reconnect) {
+  this.addFilter(FILTER_TYPE_TRACKING, keyword, reconnect)
+}
+
+Twitter.prototype.trackMultiple = function (keywords, reconnect) {
+  this.addMultipleFilters(FILTER_TYPE_TRACKING, keywords, reconnect)
+}
+
 Twitter.prototype.location = function (location, reconnect) {
   this.addFilter(FILTER_TYPE_LOCATION, location, reconnect)
+}
+
+Twitter.prototype.locationMultiple = function (locations, reconnect) {
+  this.addMultipleFilters(FILTER_TYPE_LOCATION, locations, reconnect)
 }
 
 Twitter.prototype.follow = function (follow, reconnect) {
   this.addFilter(FILTER_TYPE_FOLLOW, follow, reconnect)
 }
 
+Twitter.prototype.followMultiple = function (follows, reconnect) {
+  this.addMultipleFilters(FILTER_TYPE_FOLLOW, follows, reconnect)
+}
+
 Twitter.prototype.language = function (lang, reconnect) {
   this.addFilter(FILTER_TYPE_LANGUAGE, lang, reconnect)
+}
+
+Twitter.prototype.languageMultiple = function (langs, reconnect) {
+  this.addMultipleFilters(FILTER_TYPE_LANGUAGE, langs, reconnect)
 }
 
 Twitter.prototype.tracking = function () {
@@ -256,10 +272,10 @@ Twitter.prototype.connect = function () {
     // Handle this: https://dev.twitter.com/docs/streaming-apis/connecting#Stalls
     // Abort the connection and reconnect if we haven't received an update for 90 seconds
     var close = (function () {
-        this.abort()
-        process.nextTick(this.connect.bind(this))
-        this.emit('reconnect', {type: 'stall'})
-      }).bind(this)
+      this.abort()
+      process.nextTick(this.connect.bind(this))
+      this.emit('reconnect', {type: 'stall'})
+    }).bind(this)
 
     this.timeout = setTimeout(close, this.timeoutInterval)
 


### PR DESCRIPTION
I noticed that only the keyword tracking had an option to add multiple keywords to filter at once. I abstracted this logic out of the function and applied it to all possible filters.