### PR TITLE
add explanation string and don't reconnect on 4xx status code

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -254,25 +254,30 @@ Twitter.prototype.connect = function () {
 
   this.stream.on('response', (function (res) {
     var self = this
-    // Rate limited...
-    if (res.statusCode === 420) {
+    // Rate limited or temporarily unavailable
+    if (res.statusCode === 420 || res.statusCode === 503) {
+      var backoff = res.statusCode === 420 ? this.rateBackoff() : this.httpBackoff();
       this.abort()
       setTimeout(function () {
         self.connect()
-      }, this.rateBackoff())
+      }, backoff)
 
-      this.emit('reconnect', {type: 'rate-limit'})
+      this.emit('reconnect', {
+        type: this.errorExplanation[res.statusCode].type,
+        explain: this.errorExplanation[res.statusCode]
+      })
       return
     }
 
     // Http error
     if (res.statusCode > 200) {
       this.abort()
-      setTimeout(function () {
-        self.connect()
-      }, this.httpBackoff())
 
-      this.emit('reconnect', {type: 'http', err: new Error('Twitter connection error' + res.statusCode)})
+      this.emit('reconnect', {
+        type: 'http',
+        err: new Error('Twitter connection error ' + res.statusCode),
+        explain: this.errorExplanation[res.statusCode]
+      })
       return
     }
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -273,7 +273,7 @@ Twitter.prototype.connect = function () {
     if (res.statusCode > 200) {
       this.abort()
 
-      this.emit('reconnect', {
+      this.emit('error', {
         type: 'http',
         err: new Error('Twitter connection error ' + res.statusCode),
         explain: this.errorExplanation[res.statusCode]

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -200,6 +200,41 @@ Twitter.prototype.hasFilters = function () {
   return this.tracking().length > 0 || this.locations().length > 0 || this.following().length > 0 || this.languages().length > 0
 }
 
+Twitter.prototype.errorExplanation = {
+  401: {
+    type: 'unauthorized',
+    long: 'HTTP authentication failed.'
+  },
+  403: {
+    type: 'forbidden',
+    long: 'The connecting account is not permitted to access this endpoint.'
+  },
+  404: {
+    type: 'not-found',
+    long: 'There is nothing at this URL.'
+  },
+  406: {
+    type: 'not-acceptable',
+    long: 'At least one request parameter is invalid.'
+  },
+  413: {
+    type: 'too-long',
+    long: 'A parameter list is too long.'
+  },
+  416: {
+    type: 'range-unacceptable',
+    long: 'Returned if user does not have access to use the count parameter or a count parameter is outside of the max/min allowable values.'
+  },
+  420: {
+    type: 'rate-limit',
+    long: 'The client has connected too frequently.'
+  },
+  503: {
+    type: 'service-unavailable',
+    long: 'A streaming server is temporarily overloaded.'
+  }
+}
+
 Twitter.prototype.connect = function () {
   this.stale = false
   if (!this.hasFilters()) {

--- a/test/twitter.js
+++ b/test/twitter.js
@@ -19,8 +19,8 @@ describe('twitter', function () {
     assert.throws(function () { new Twitter({}) }, Error)
   })
 
-  it('emits reconnect', function (done) {
-    twitter.on('reconnect', function (obj) {
+  it('emits error', function (done) {
+    twitter.on('error', function (obj) {
       assert(obj)
       assert(obj.err.message)
       assert(obj.err.message.match(/401/)) // Bad twitter oauth credentials


### PR DESCRIPTION
As we can see in all these 4xx errors, it's all due to the user's fault who construct an illegal query. In such case no matter how many reconnections you tried, the result will still be the same. Thus I think make the stream abort and emit 'error' would be appropriate.

And when an 4xx error occur, providing some short explanation might be good for debugging.