### PR TITLE
Adds support for gzip and deflate compression

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -2,6 +2,7 @@ var request = require('request')
   , split = require('split')
   , Writable = require('stream').Writable
   , util = require('util')
+  , zlib = require('zlib')
 
 function backoff (current, max, step, _value) {
   return function () {
@@ -209,6 +210,7 @@ Twitter.prototype.connect = function () {
   this.stream = request.post({
     url: this.twitterUrl,
     oauth: this.oauth,
+	gzip: true,
     form: {
       track: Object.keys(this._filters[FILTER_TYPE_TRACKING]).join(','),
       locations: Object.keys(this._filters[FILTER_TYPE_LOCATION]).join(','),
@@ -252,8 +254,18 @@ Twitter.prototype.connect = function () {
       } catch (e) {}
     })
 
-    this.parser = res.pipe(this.parser, {end: false})
-    this.parser.pipe(this)
+	var encoding = res.headers['content-encoding']
+    if (encoding === 'gzip') {
+		console.log('initializing gunzip');
+		this.parser = res.pipe(zlib.createGunzip()).pipe(this.parser, {end: false})
+		this.parser.pipe(this)
+    } else if (encoding === 'deflate') {
+		this.parser = res.pipe(zlib.createInflate()).pipe(this.parser, {end: false})
+		this.parser.pipe(this)
+    } else {
+		this.parser = res.pipe(this.parser, {end: false})
+		this.parser.pipe(this)
+    }
 
     // Handle this: https://dev.twitter.com/docs/streaming-apis/connecting#Stalls
     // Abort the connection and reconnect if we haven't received an update for 90 seconds


### PR DESCRIPTION
Twitter can support gzip compression. I added the option gzip: true to the request and added code to handle either gzip, deflate or none.

I took a quick look at how the tests were set up and I could create tests for this if wanted. But I wanted someone to review first.