### PR TITLE
add default listener for the new 'error' event

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -252,6 +252,12 @@ Twitter.prototype.connect = function () {
     }
   })
 
+  this.once('error', function (err) {
+    console.log('Encountered an unrecoverable error, the stream is abort.')
+    console.log('  Reason: [', err.code, ']', err.explain.long)
+    console.log('  Please refer to https://dev.twitter.com/streaming/overview/connecting to debug your request parameters.')
+  })
+
   this.stream.on('response', (function (res) {
     var self = this
     // Rate limited or temporarily unavailable
@@ -276,6 +282,7 @@ Twitter.prototype.connect = function () {
       this.emit('error', {
         type: 'http',
         err: new Error('Twitter connection error ' + res.statusCode),
+        code: res.statusCode,
         explain: this.errorExplanation[res.statusCode]
       })
       return


### PR DESCRIPTION
Since current parameter checking is more strict, some underlying errors may be reported after updated this module. To reduce the confusions from people who suddenly found their code not working and complained about `Uncaught 'error' event`, I suggest adding a default listener for 'error' events to show people the way to their resolution.