### PR TITLE
Avoid closing stream when destroying parser

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -300,7 +300,7 @@ Twitter.prototype.connect = function () {
     })
 
     this.parser = res.pipe(this.parser, {end: false})
-    this.parser.pipe(this)
+    this.parser.pipe(this, {end: false})
 
     // Handle this: https://dev.twitter.com/docs/streaming-apis/connecting#Stalls
     // Abort the connection and reconnect if we haven't received an update for 90 seconds


### PR DESCRIPTION
Hi,

I was having some trouble using this module with node 8. If you run following snippet on node 6, after 30 seconds it adds new keyword, reconnects and continue emitting tweets. On node 8 however, it stops emitting after reconnect. Connection to Twitter results with `200 Success` and after some debugging, connection is live and content is arriving.

```js
const TweetStream = require('node-tweet-stream')

const stream = new TweetStream({
  consumer_key: process.env.TWITTER_CONSUMER_KEY,
  consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
  token: process.env.TWITTER_ACCESS_TOKEN,
  token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET
})
stream.on('error', (err) => log(`error: ${err.message}`))
stream.on('tweet', (tweet) => log('tweet'))
stream.on('connect', () => log(`tracking: ${stream.tracking().join(',')}`))

log('track')
stream.track('apple')

setTimeout(() => {
  log('track')
  stream.track('google')
}, 30 * 1000)

function log (msg) {
  console.log('%s: %s', (new Date()).toISOString(), msg)
}
```

With previous node versions, [following code](https://github.com/SpiderStrategies/node-tweet-stream/blob/v2.0.1/lib/twitter.js#L333) does not end stream even if it should since [here](https://github.com/SpiderStrategies/node-tweet-stream/blob/v2.0.1/lib/twitter.js#L303), `this.parser.pipe(this)` is done without `{end: false}`.

This pull request resolves this issue.