### PR TITLE
Add extended tweet parameter to get tweets longer than 140 characters.

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -264,7 +264,7 @@ Twitter.prototype.connect = function () {
       language: Object.keys(this._filters[FILTER_TYPE_LANGUAGE]).join(','),
       
       // Include tweet_mode like this to not include it if it is not specified
-      {...this.tweet_mode}
+      ...this.tweet_mode
     }
   })
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -27,7 +27,20 @@ var Twitter = function (oauth) {
   if (!oauth || !oauth.consumer_secret || !oauth.consumer_key || !oauth.token || !oauth.token_secret) {
     throw new Error('Oauth credentials required')
   }
+  
   this.oauth = oauth
+  
+  // Define tweet_mode like this so that we don't include it at all in the API request if not specified.
+  // No value other than 'extended' for tweet_mode is documented (e.g 'normal')
+  this.tweet_mode = oauth.tweet_mode ? {tweet_mode: oauth.tweet_mode} : {}
+  
+  // Also register 'extended' param
+  if ( oauth.extended ) {
+    this.tweet_mode = {tweet_mode: 'extended'} 
+  }
+  
+  // Delete tweet_mode key from oAuth to not include it in that section
+  delete this.oauth['tweet_mode']
 
   this._filters = {
     tracking: {},
@@ -248,7 +261,10 @@ Twitter.prototype.connect = function () {
       track: Object.keys(this._filters[FILTER_TYPE_TRACKING]).join(','),
       locations: Object.keys(this._filters[FILTER_TYPE_LOCATION]).join(','),
       follow: Object.keys(this._filters[FILTER_TYPE_FOLLOW]).join(','),
-      language: Object.keys(this._filters[FILTER_TYPE_LANGUAGE]).join(',')
+      language: Object.keys(this._filters[FILTER_TYPE_LANGUAGE]).join(','),
+      
+      // Include tweet_mode like this to not include it if it is not specified
+      {...this.tweet_mode}
     }
   })
 


### PR DESCRIPTION
This adds two new parameters in the dict passed to the constructor of the node-tweet-stream object.

`tweet_mode` controls the tweet_mode parameter in the API request via a string.
`extended` is a boolean that sets tweet_mode to 'extended' if true or null/not included if false.